### PR TITLE
allow empty labels

### DIFF
--- a/tutorials/textcat_goemotions/scripts/convert_corpus.py
+++ b/tutorials/textcat_goemotions/scripts/convert_corpus.py
@@ -17,7 +17,7 @@ def read_tsv(file_):
         text, labels, annotator = line.split("\t")
         yield {
             "text": text,
-            "labels": [int(label) for label in labels.split(",")],
+            "labels": [int(label) for label in labels.split(",") if label != ''],
             "annotator": annotator
         }
 


### PR DESCRIPTION
Modified the read_tsv function so that custom .tsv formatted data can easily be used even if some lines have no labels. For example, if there is a non-exclusive multi-label model where it is possible for none of the labels to apply, this modification allows that line in .tsv to have an empty string entry in the labels column, since when that is .split(',') it gives [''] and we can simply exclude taking int('') by adding if label != ''